### PR TITLE
changed layers, bat.tscn behaviour, collision boxes, restart button

### DIFF
--- a/Characters/Scripts/bat.gd
+++ b/Characters/Scripts/bat.gd
@@ -1,6 +1,7 @@
 extends CharacterBody2D
 
-
+enum States{DEFAULT, DEAD}
+var state = States.DEFAULT
 var speed = 50.0
 var move_direction = -1
 var gravity = ProjectSettings.get_setting("physics/2d/default_gravity")
@@ -9,15 +10,28 @@ var gravity = ProjectSettings.get_setting("physics/2d/default_gravity")
 func _ready():
 	$AnimationPlayer.play("fly")
 
+func kill():
+	if state != States.DEAD:
+		state = States.DEAD
+		$AnimationPlayer.play("hit")
+
+func alive() -> bool:
+	if state != States.DEAD:
+		return true
+	return false
+
 func _physics_process(delta):
-	if raybat.is_colliding():
-		move_direction *= -1
-		raybat.scale *= -1
-	if move_direction < 0:
-		$Sprite2D.flip_h = false
-	else:
-		$Sprite2D.flip_h = true
-		
-	velocity.x = speed * move_direction
-	
+	if state == States.DEFAULT:
+		if raybat.is_colliding():
+			move_direction *= -1
+			#raybat.scale *= -1 usually altering scale is a bad thing specially with collisions, can cause weird bugs
+			raybat.target_position = Vector2(50, 0) * move_direction
+		if move_direction < 0:
+			$Sprite2D.flip_h = false
+		else:
+			$Sprite2D.flip_h = true
+		velocity.x = speed * move_direction
+	elif state == States.DEAD:
+		velocity.x = move_toward(velocity.x, 0, (speed * delta) / 0.8)
+		velocity.y += gravity * delta
 	move_and_slide()

--- a/Characters/Scripts/mask_dude.gd
+++ b/Characters/Scripts/mask_dude.gd
@@ -38,8 +38,18 @@ func jump():
 		$Jump.play()
 		jump_count += 1
 		print(jump_count)
-	
 
+func bounce():
+	velocity.y = jump_speed
+
+func check_collision():
+	for i in get_slide_collision_count():
+		var collider = get_slide_collision(i).get_collider()
+		if collider.is_in_group("bat"):
+			if position.y < collider.position.y:
+				if collider.alive():
+					bounce()
+				collider.kill()
 
 func _physics_process(delta):
 	if not is_on_floor():
@@ -53,5 +63,8 @@ func _physics_process(delta):
 	vertical_animation()
 	jump()
 	move_and_slide()
-	
+	check_collision()
 
+func _input(event):
+	if event.is_action_pressed("restart"):
+		get_tree().reload_current_scene()

--- a/Characters/bat.tscn
+++ b/Characters/bat.tscn
@@ -88,7 +88,6 @@ tracks/2/keys = {
 [sub_resource type="Animation" id="Animation_btpu4"]
 resource_name = "hit"
 length = 0.5
-loop_mode = 1
 tracks/0/type = "value"
 tracks/0/imported = false
 tracks/0/enabled = true
@@ -133,11 +132,13 @@ _data = {
 "hit": SubResource("Animation_btpu4")
 }
 
-[sub_resource type="CapsuleShape2D" id="CapsuleShape2D_f3k1x"]
-radius = 11.0
-height = 40.0
+[sub_resource type="CircleShape2D" id="CircleShape2D_fr0wi"]
+radius = 7.07107
 
-[node name="Bat" type="CharacterBody2D"]
+[node name="Bat" type="CharacterBody2D" groups=["bat"]]
+collision_layer = 4
+collision_mask = 2
+motion_mode = 1
 script = ExtResource("1_7lmv1")
 
 [node name="Sprite2D" type="Sprite2D" parent="."]
@@ -152,8 +153,9 @@ libraries = {
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="."]
 rotation = 1.5708
-shape = SubResource("CapsuleShape2D_f3k1x")
+shape = SubResource("CircleShape2D_fr0wi")
 
 [node name="RayBat" type="RayCast2D" parent="."]
 target_position = Vector2(-50, 0)
+collision_mask = 2
 collide_with_areas = true

--- a/Characters/mask_dude.tscn
+++ b/Characters/mask_dude.tscn
@@ -345,8 +345,11 @@ _data = {
 }
 
 [sub_resource type="CapsuleShape2D" id="CapsuleShape2D_ldfdr"]
+radius = 9.0
+height = 28.0
 
-[node name="MaskDude" type="CharacterBody2D"]
+[node name="MaskDude" type="CharacterBody2D" groups=["player"]]
+collision_mask = 6
 script = ExtResource("1_i50p7")
 
 [node name="Texture" type="Sprite2D" parent="."]
@@ -360,6 +363,7 @@ libraries = {
 }
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="."]
+position = Vector2(0, 2)
 shape = SubResource("CapsuleShape2D_ldfdr")
 
 [node name="Camera2D" type="Camera2D" parent="."]

--- a/Levels/level_01.tscn
+++ b/Levels/level_01.tscn
@@ -1857,7 +1857,7 @@ texture = ExtResource("9_fmwai")
 6:5/0/physics_layer_0/angular_velocity = 0.0
 
 [sub_resource type="TileSet" id="TileSet_ckqyf"]
-physics_layer_0/collision_layer = 1
+physics_layer_0/collision_layer = 2
 terrain_set_0/mode = 2
 terrain_set_0/terrain_0/name = "Base_Terrain"
 terrain_set_0/terrain_0/color = Color(0.5, 0.34375, 0.25, 1)

--- a/project.godot
+++ b/project.godot
@@ -45,6 +45,17 @@ climb={
 , Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":4194320,"key_label":0,"unicode":0,"echo":false,"script":null)
 ]
 }
+restart={
+"deadzone": 0.5,
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":82,"key_label":0,"unicode":114,"echo":false,"script":null)
+]
+}
+
+[layer_names]
+
+2d_physics/layer_1="player"
+2d_physics/layer_2="static block"
+2d_physics/layer_3="bat"
 
 [rendering]
 


### PR DESCRIPTION
- changed name of layers and changed collision layers/masks of player, blocks/tilemaps and bat
- adjusted player and bat collision shapes, where to big, visual disconect between collision and sprites
- bat behaviour altered, now only flips when colliding with tilemap blocks with collision, dies when player hits it from above, bouncing the player
- added restart button, pressing R now restarts current scene, good for testing